### PR TITLE
Add serde

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd fss
 cargo build --release
 ```
 
-_Note: The `nightly` toolchain is required since we use the unstable `min_specialization` feature to lower communication costs. No other unstable features are used._
+_Note: The `nightly` toolchain is required since we use the unstable [`min_specialization` feature](https://github.com/rust-lang/rfcs/pull/1210) to lower communication costs. No other unstable features are used._
 
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -14,23 +14,26 @@ This library provides Rust crates for a few different types of FSS schemes:
 
 ## Build guide
 
-The library compiles on the `stable` toolchain of the Rust compiler (v 1.57+). To install the latest version of Rust, first install `rustup` by following the instructions [here](https://rustup.rs/), or via your platform's package manager. Once `rustup` is installed, install the Rust toolchain by invoking:
+The library compiles on the `nightly` toolchain of the Rust compiler (v 1.59+). To install the latest version of Rust, first install `rustup` by following the instructions [here](https://rustup.rs/), or via your platform's package manager. Once `rustup` is installed, install the Rust toolchain by invoking:
 
 ```bash
-rustup install stable
+rustup install nightly
 ```
 
 After that, use `cargo`, the standard Rust build tool, to build the libraries:
 
 ```bash
-git clone https://github.com/ryanleh/fss-rs.git
-cd fss-rs
+git clone https://github.com/ryanleh/fss.git
+cd fss
 cargo build --release
 ```
 
+_Note: The `nightly` toolchain is required since we use the unstable `min_specialization` feature to lower communication costs. No other unstable features are used._
+
+
 ## Tests
 
-This library comes with comprehensive unit and integration tests for each of the provided crates. Run the tests with:
+This library comes with comprehensive tests for each of the provided crates. Run the tests with:
 
 ```bash
 cargo test --all

--- a/dpf/Cargo.toml
+++ b/dpf/Cargo.toml
@@ -9,9 +9,11 @@ edition = "2021"
 [dependencies]
 ark-ff = "^0.3.0"
 rand = "^0.8.4" 
+serde = { version = "^1.0.132", features = [ "derive", "rc" ] }
 
 [dev-dependencies]
 ark-std = "^0.3.0"
+bincode = "^1.3.3"
 criterion = "^0.3"
 rand_chacha = "^0.3.1"
 

--- a/dpf/README.md
+++ b/dpf/README.md
@@ -2,6 +2,7 @@
 
 This crate implements traits and implementations for distributed point functions.
 
+
 ## Reference papers
 
 [bgi18]: https://www.iacr.org/archive/eurocrypt2015/90560300/90560300.pdf

--- a/dpf/src/bgi18/mod.rs
+++ b/dpf/src/bgi18/mod.rs
@@ -27,11 +27,11 @@ where
     PRG: CryptoRng + RngCore + SeedableRng<Seed = S>,
     S: Seed,
 {
-    /// Converts a `usize` to a vector of bytes in little endian format
+    /// Converts a `usize` to a vector of bools in little endian format
     #[inline]
     fn usize_to_bits(log_domain: usize, val: usize) -> Result<Vec<bool>, Box<dyn Error>> {
         // Ensure that the point is valid in the given domain
-        if val >= 2usize.pow(log_domain as u32) {
+        if val >= (1 << log_domain) {
             return Err("Input point is not contained in provided domain")?;
         }
 
@@ -41,7 +41,7 @@ where
         // Compute the bit-decomposition
         let bytes = val.to_le_bytes();
         for i in 0..log_domain {
-            let mask = 2u8.pow((i % 8) as u32);
+            let mask = 1 << (i % 8);
             let bit = mask & bytes[(i / 8) as usize];
             bits.push(bit != 0);
         }

--- a/dpf/src/lib.rs
+++ b/dpf/src/lib.rs
@@ -1,6 +1,9 @@
+#![feature(min_specialization)]
+
 //! A crate implementing various distributed point function schemes
 use ark_ff::Field;
 use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 use std::error::Error;
 
 /// DPF scheme based on [[BGI18]].
@@ -17,7 +20,7 @@ pub(crate) mod tests;
 pub trait DPF<F: Field> {
     /// A succinct representation of a function which outputs shares of the underlying point
     /// function
-    type Key;
+    type Key: Serialize + for<'de> Deserialize<'de>;
 
     /// Takes the description of a point function as input -- where the point is a field element --
     /// and outputs two `Key`s.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This PR:
* `Pair` is converted to a newtype struct
* Some power-of-two logic was simplified by using bit operators
* Adds serde bounds for the `dpf::DPF::Key` struct and all structs contained in it. `Pair<bool>` serialization is specialized to pack bits into a single `u8` (rather than two) which requires the `min_specialization` feature.
* As a result of the above, toolchain is switched to nightly
* Added serialization tests