### PR TITLE
Update serialization

### DIFF
--- a/funcs/Cargo.toml
+++ b/funcs/Cargo.toml
@@ -7,12 +7,14 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-ark-ff = "^0.3.0"
+#ark-ff = "^0.3.0"
+#ark-serialize = "^0.3.0"
+ark-ff = { path = "../../algebra/ff" }
+ark-serialize = { path = "../../algebra/serialize", features = ["derive"] }
+ark-std = "^0.3.0"
 rand = "^0.8.4" 
-serde = { version = "^1.0.132", features = [ "derive", "rc" ] }
 
 [dev-dependencies]
-ark-std = "^0.3.0"
 bincode = "^1.3.3"
 criterion = "^0.3"
 rand_chacha = "^0.3.1"

--- a/funcs/Cargo.toml
+++ b/funcs/Cargo.toml
@@ -7,10 +7,8 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-#ark-ff = "^0.3.0"
-#ark-serialize = "^0.3.0"
-ark-ff = { path = "../../algebra/ff" }
-ark-serialize = { path = "../../algebra/serialize", features = ["derive"] }
+ark-ff = { git="https://github.com/arkworks-rs/algebra" }
+ark-serialize = { git="https://github.com/arkworks-rs/algebra", features = ["derive"] }
 ark-std = "^0.3.0"
 rand = "^0.8.4" 
 

--- a/funcs/src/lib.rs
+++ b/funcs/src/lib.rs
@@ -7,7 +7,6 @@ use ark_std::io::{Read, Write};
 use std::ops::{Index, IndexMut};
 
 pub mod point;
-//pub mod interval;
 
 /// A PRG seed
 pub trait Seed:

--- a/funcs/src/lib.rs
+++ b/funcs/src/lib.rs
@@ -1,3 +1,97 @@
 #![feature(min_specialization)]
+use ark_serialize::{
+    CanonicalDeserialize as Deserialize, CanonicalSerialize as Serialize, SerializationError,
+};
+use ark_std::io::{Read, Write};
+
+use std::ops::{Index, IndexMut};
 
 pub mod point;
+//pub mod interval;
+
+/// A PRG seed
+pub trait Seed:
+    Sized + Default + Copy + AsRef<[u8]> + AsMut<[u8]> + Serialize + Deserialize
+{
+}
+impl Seed for [u8; 16] {}
+impl Seed for [u8; 32] {}
+
+/// A container for two identical-type objects which can be indexed using `bool`
+#[derive(Copy, Clone, Default, Eq, PartialEq)]
+pub struct Pair<T>([T; 2]);
+
+impl<T> Pair<T> {
+    #[inline]
+    pub fn new(first: T, second: T) -> Self {
+        Self([first, second])
+    }
+}
+
+impl<T: Sized + Clone> Index<usize> for Pair<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        assert!(index == 0 || index == 1);
+        &self.0[index]
+    }
+}
+
+impl<T: Sized + Clone> IndexMut<usize> for Pair<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        assert!(index == 0 || index == 1);
+        &mut self.0[index]
+    }
+}
+
+impl<T: Sized + Clone> Index<bool> for Pair<T> {
+    type Output = T;
+
+    fn index(&self, index: bool) -> &Self::Output {
+        &self.0[index as usize]
+    }
+}
+
+impl<T: Sized + Clone> IndexMut<bool> for Pair<T> {
+    fn index_mut(&mut self, index: bool) -> &mut Self::Output {
+        &mut self.0[index as usize]
+    }
+}
+
+impl<T: Serialize> Serialize for Pair<T> {
+    default fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        self.0.serialize(&mut writer)
+    }
+
+    default fn serialized_size(&self) -> usize {
+        self.0.serialized_size()
+    }
+}
+
+impl<T: Deserialize + Copy + Default> Deserialize for Pair<T> {
+    #[inline]
+    default fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        Ok(Pair(<[T; 2]>::deserialize(&mut reader)?))
+    }
+}
+
+/// For `Pair<bool>` we can save space by encoding both bits into a single `u8`.
+impl Serialize for Pair<bool> {
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        let byte: u8 = (self[0] as u8) << 1 | self[1] as u8;
+        byte.serialize(&mut writer)
+    }
+
+    default fn serialized_size(&self) -> usize {
+        1
+    }
+}
+
+/// For `Pair<bool>` we can save space by encoding both bits into a single `u8`.
+impl Deserialize for Pair<bool> {
+    #[inline]
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let byte = <u8>::deserialize(&mut reader)?;
+        Ok(Pair([(byte & 2) == 2, (byte & 1) == 1]))
+    }
+}

--- a/funcs/src/point/bgi18/mod.rs
+++ b/funcs/src/point/bgi18/mod.rs
@@ -2,7 +2,7 @@ use ark_ff::Field;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 use std::{error::Error, marker::PhantomData, rc::Rc, vec::Vec};
 
-use super::DPF;
+use crate::{point::DPF, Pair, Seed};
 
 mod data_structures;
 pub use data_structures::*;

--- a/funcs/src/point/mod.rs
+++ b/funcs/src/point/mod.rs
@@ -1,7 +1,7 @@
 //! A module implementing various distributed point function schemes
 use ark_ff::Field;
+use ark_serialize::{CanonicalDeserialize as Deserialize, CanonicalSerialize as Serialize};
 use rand::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 use std::error::Error;
 
 #[cfg(test)]
@@ -18,9 +18,9 @@ pub mod bgi18;
 pub trait DPF<F: Field> {
     /// A succinct representation of a function which outputs shares of the underlying point
     /// function
-    type Key: Serialize + for<'de> Deserialize<'de>;
+    type Key: Serialize + Deserialize;
 
-    /// Takes the description of a point function as input -- where the point is a field element --
+    /// Takes the description of a point function as input -- where the value is a field element --
     /// and outputs two `Key`s.
     fn gen<RNG: CryptoRng + RngCore>(
         domain: usize,


### PR DESCRIPTION
This PR moves the `Seed` and `Pair` objects to `lib.rs` + changes serialization from `serde` to `arkworks-rs` since it allows for more derives.